### PR TITLE
Add support for Zulu JDK17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update && apt-get install -y \
   software-properties-common \
   curl
 
-# Install Zulu OpenJdk 11 (LTS)
+# Install Zulu OpenJdk 17 (LTS)
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 \
   && apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
-  && apt install -y zulu-11
+  && apt install -y zulu-17
 
 # Unpack and install the kernel
 RUN curl -L https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip > ijava-kernel.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,15 @@ RUN apt-get update && apt-get install -y \
   curl
 
 # Install Zulu OpenJdk 17 (LTS)
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 \
-  && apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
-  && apt install -y zulu-17
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+# download and install the package that adds 
+# the Azul APT repository to the list of sources 
+RUN curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
+# install the package
+RUN apt install ./zulu-repo_1.0.0-3_all.deb
+# update the package sources
+RUN apt update
+RUN apt install -y zulu17-jdk
 
 # Unpack and install the kernel
 RUN curl -L https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip > ijava-kernel.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt install ./zulu-repo_1.0.0-3_all.deb
 # update the package sources
 RUN apt update
 RUN apt install -y zulu17-jdk
+RUN rm ./zulu-repo_1.0.0-3_all.deb
 
 # Unpack and install the kernel
 RUN curl -L https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip > ijava-kernel.zip

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ ijava-jupyter-stack is a Jupyter Docker Stack image that's including the IJAVA K
 # Launch on binder
 Try this Jupyter Notebook online with this link. No installation is needed.
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jbindinga/java-notebook/master)
+
+Launch this with JDK17 support.
 [![JDK17 Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nilshoffmann/java-notebook/jdk17)
 
 # Docker Hub

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ijava-jupyter-stack is a Jupyter Docker Stack image that's including the IJAVA K
 # Launch on binder
 Try this Jupyter Notebook online with this link. No installation is needed.
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jbindinga/java-notebook/master)
+[![JDK17 Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nilshoffmann/java-notebook/jdk17)
 
 # Docker Hub
 * Docker Hub [hub.docker.com/r/jbindinga/java-notebook](https://hub.docker.com/r/jbindinga/java-notebook)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ ijava-jupyter-stack is a Jupyter Docker Stack image that's including the IJAVA K
 Try this Jupyter Notebook online with this link. No installation is needed.
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jbindinga/java-notebook/master)
 
-Launch this with JDK17 support.
-[![JDK17 Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nilshoffmann/java-notebook/jdk17)
-
 # Docker Hub
 * Docker Hub [hub.docker.com/r/jbindinga/java-notebook](https://hub.docker.com/r/jbindinga/java-notebook)
 


### PR DESCRIPTION
This PR updates the Azul Zulu installation to JDK17.
Testing in my binder with a custom Java Notebook using the updated Dockerfile was successful:
https://mybinder.org/v2/gh/nilshoffmann/java-notebook/jmzqc?urlpath=/lab/workspaces/auto-g/tree/jmzqc-demo.ipynb
